### PR TITLE
fix step decorator name resolution...

### DIFF
--- a/test-step-decorators/tests/base.ts
+++ b/test-step-decorators/tests/base.ts
@@ -26,7 +26,7 @@ export function step(stepName?: string) {
     context: ClassMethodDecoratorContext
   ) {
     return function replacementMethod(...args: any) {
-      const name = `${stepName || (context.name as string)} (${this.name})`
+      const name = `${stepName || (context.name as string)} (${this.constructor.name})`
       return test.step(name, async () => {
         return await target.call(this, ...args)
       })


### PR DESCRIPTION
Thank you for the nice decorator :)

When using it, I found this issue:

In UI mode for example the step was displayed as: `<my method name> (undefined)`

After fix: `<my method name> (<my class name>)`